### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 
 All Ansible networking collections contributed by Nokia are now available from:
 https://github.com/nokia/ansible-networking-collections
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/sros-ansible/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.