### PR TITLE
fix CLI context behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tests/clab-*
 *.log
 license.*
 .DS_Store
+.build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Support for `flat` and `xml` output formats in `get_config()`
+- Support for `intended` as a valid configuration source in `get_config()`
+- Support for commit comments in `edit_config()` using the `comment` parameter
+
+### Changed
+- Inherid base-class RPCs, while adding the SROS specific ones
+- Use `info /` and `compare /` to ensure all tree levels are included in output
+- Construct `info` commands using `' '.join()` to prevent trailing/double spaces when optional parameters are not provided
+- Added exception handling for rollback
+
+### Fixed
+- Ensure `load full-replace` and `rollback` commands are correctly executed in CLI context `configure`
+- Ensure `quit-config` is correctly executed in CLI root context
+
 ## [2.0.0]
 ### Added
 - Containerlab topology as test-automation reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0]
 ### Added
 - Support for `flat` and `xml` output formats in `get_config()`
 - Support for `intended` as a valid configuration source in `get_config()`
+- Support for `active` as a valid configuration source in `get_config()`
+  Same as `running` but excludes index persistency.
 - Support for commit comments in `edit_config()` using the `comment` parameter
+- Support `replace` with local file in `edit_config()`
 
 ### Changed
 - Inherid base-class RPCs, while adding the SROS specific ones

--- a/plugins/cliconf/md.py
+++ b/plugins/cliconf/md.py
@@ -211,7 +211,7 @@ class Cliconf(CliconfBase):
         elif source == 'candidate':
             response = self.send_command(' '.join(['info'] + flags + ['/']))
         else:
-            response = self.send_command(' '.join(['/admin show configuration', source] + flags))
+            response = self.send_command(' '.join(['info', source] + flags + ['/']))
 
         return response
 

--- a/plugins/cliconf/md.py
+++ b/plugins/cliconf/md.py
@@ -247,6 +247,10 @@ class Cliconf(CliconfBase):
                         requests.append(cmd)
                         responses.append(self.send_command(cmd))
             elif replace:
+                if not bool(re.match(r'^[cC][fF][12345]:', replace)):
+                    self._connection.copy_file(source=replace, destination='ansible.cfg', proto='scp', timeout=30)
+                    replace = 'ansible.cfg'
+
                 self.send_command('configure')
                 self.send_command('load full-replace {0}'.format(replace).strip())
 

--- a/plugins/cliconf/md.py
+++ b/plugins/cliconf/md.py
@@ -1,4 +1,4 @@
-# (c) 2025 Nokia
+# (c) 2026 Nokia
 #
 # Licensed under the BSD 3 Clause license
 # SPDX-License-Identifier: BSD-3-Clause
@@ -35,28 +35,24 @@ except ImportError:
 class Cliconf(CliconfBase):
 
     def get_device_operations(self):
-        return {                                    # supported: ---------------
-            'supports_commit': True,                # identify if commit is supported by device or not
-            'supports_rollback': True,              # identify if rollback is supported or not
-            'supports_defaults': True,              # identify if fetching running config with default is supported
-            'supports_onbox_diff': True,            # identify if on box diff capability is supported or not
-            'supports_replace': True,               # identify if running config replace with candidate config is supported
-                                                    # unsupported: -------------
-            'supports_admin': False,                # no admin-mode
-            'supports_multiline_delimiter': False,  # no multiline delimiter
-            'supports_commit_label': False,         # no commit-label
-            'supports_commit_comment': False,       # no commit-comment
-            'supports_generate_diff': False,        # not supported
-            'supports_diff_replace': False,         # not supported
-            'supports_diff_match': False,           # not supported
-            'supports_diff_ignore_lines': False     # not supported
+        return {
+            "supports_commit": True,
+            "supports_rollback": True,
+            "supports_defaults": True,
+            "supports_onbox_diff": True,
+            "supports_commit_comment": True,
+            "supports_replace": True,
+
+            "supports_multiline_delimiter": False,
+            "supports_generate_diff": False,
+            "supports_diff_replace": False,
+            "supports_diff_match": False,
+            "supports_diff_ignore_lines": False,
+
         }
 
     def get_sros_rpc(self):
         return [
-            'get_config',          # Retrieves the specified configuration from the device
-            'edit_config',         # Loads the specified commands into the remote device
-            'get',                 # Execute specified command on remote device
             'get_capabilities',    # Retrieves device information and supported rpc methods
             'get_default_flag',    # CLI option to include defaults for config dumps
             'commit',              # Load configuration from candidate to running
@@ -64,9 +60,8 @@ class Cliconf(CliconfBase):
         ]
 
     def get_option_values(self):
-        # format: json is supported from SROS19.10 onwards in MD MODE only
         return {
-            'format': ['text', 'json'],
+            'format': ['text', 'flat', 'json', 'xml'],
             'diff_match': [],
             'diff_replace': [],
             'output': ['text']
@@ -103,7 +98,7 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         capabilities = super(Cliconf, self).get_capabilities()
         capabilities['device_operations'] = self.get_device_operations()
-        capabilities['rpc'] = self.get_sros_rpc()
+        capabilities['rpc'] += self.get_sros_rpc()
         capabilities['device_info'] = self.get_device_info()
         capabilities['network_api'] = 'cliconf'
         capabilities.update(self.get_option_values())
@@ -127,7 +122,7 @@ class Cliconf(CliconfBase):
         plugin is using private mode to avoid interference with concurrent
         MD-CLI or NETCONF sessions.
 
-        Note, that is Ansible module will use "edit-config private" and
+        Note, that is Ansible module uses "edit-config private" and
         "quit-config" to enter and leave configuration mode. The
         alternative of using "configure private" is not supported.
 
@@ -177,7 +172,14 @@ class Cliconf(CliconfBase):
         return not match or match.group(1) == 'classic'
 
     def get_config(self, source='running', format='text', flags=None):
-        if source not in ('startup', 'running', 'candidate'):
+        # This Ansible module exits config-mode after any edit-config operation.
+        # Therefore, accessing source='candidate' (when running in config-mode)
+        # has been implemented for completeness only.
+
+        if flags is None:
+            flags = []
+
+        if source not in ('startup', 'candidate', 'running', 'intended'):
             raise ValueError("fetching configuration from %s is not supported" % source)
 
         if format not in self.get_option_values()['format']:
@@ -189,38 +191,27 @@ class Cliconf(CliconfBase):
         if self.is_classic_cli():
             self.send_command('/!md-cli')
 
-        if format == 'text':
-            cmd = 'info %s %s' % (source, ' '.join(flags))
-        else:
-            cmd = 'info %s %s %s' % (source, format, ' '.join(flags))
+        if source == 'startup' and self.is_config_mode():
+            raise ValueError("fetching startup configuration in config mode is not supported")
 
-        self.send_command('exit all')
-        if self.is_config_mode():
-            # This Ansible module always exists config-mode after any edit-config
-            # MD-CLI operation. Therefore the code below should actually never be
-            # executed.
-            # If get_config() is called with source='candidate', it is somewhat
-            # assumed that we are in config-mode, because in operational mode
-            # there is no candidate (aka candidate=running).
+        if source == 'candidate' and not self.is_config_mode():
+            raise ValueError("fetching candidate configuration is only supported in config mode")
 
-            response = self.send_command(cmd.strip())
-        else:
-            # This Ansible plugin calls 'info' rather then 'admin show configuration'
-            # because it provides additional options such as 'info detail' to include
-            # default values. Also it would support alternative output formats (json).
+        if format != 'text':
+            flags = [format] + flags
 
-            if source == 'startup':
-                self.send_command('edit-config private')
-                self.send_command('configure')
-                self.send_command('rollback startup')
-                self.send_command('exit all')
-                response = self.send_command(cmd.strip())
-                self.send_command('discard')
-            else:
-                self.send_command('edit-config read-only')
-                self.send_command('environment more false')
-                response = self.send_command(cmd.strip())
+        if source == 'startup':
+            self.enable_config_mode()
+            self.send_command('configure')
+            self.send_command('rollback startup')
+            response = self.send_command(' '.join(['info'] + flags + ['/']))
+            self.send_command('discard')
+            self.send_command('exit all')
             self.send_command('quit-config')
+        elif source == 'candidate':
+            response = self.send_command(' '.join(['info'] + flags + ['/']))
+        else:
+            response = self.send_command(' '.join(['/admin show configuration', source] + flags))
 
         return response
 
@@ -237,41 +228,49 @@ class Cliconf(CliconfBase):
         responses = []
 
         try:
-            if replace:
-                if candidate:
+            if candidate:
+                if replace:
                     cmd = 'delete configure'
-                else:
-                    cmd = 'load full-replace {0}'.format(replace).strip()
-                requests.append(cmd)
-                responses.append(self.send_command(cmd))
-
-            for cmd in to_list(candidate):
-                if isinstance(cmd, Mapping):
-                    requests.append(cmd['command'])
-                    responses.append(self.send_command(**cmd))
-                else:
                     requests.append(cmd)
                     responses.append(self.send_command(cmd))
 
-        except AnsibleConnectionFailure as exc:
-            self.send_command('exit all')
-            self.send_command('discard')
-            self.send_command('quit-config')
-            raise exc
+                for cmd in to_list(candidate):
+                    if isinstance(cmd, Mapping):
+                        requests.append(cmd['command'])
+                        responses.append(self.send_command(**cmd))
+                    else:
+                        requests.append(cmd)
+                        responses.append(self.send_command(cmd))
+            elif replace:
+                self.send_command('configure')
+                self.send_command('load full-replace {0}'.format(replace).strip())
 
-        self.send_command('exit all')
-        diffs = self.send_command('compare').strip()
-        if diffs:
+            diffs = self.send_command('compare /').strip()
+
             if commit:
-                self.send_command('commit')
-                self.send_command('quit-config')
+                if comment:
+                    safe_comment = comment.replace('"', "'")
+                    self.send_command('commit comment "%s"' % safe_comment)
+                else:
+                    self.send_command('commit')
             else:
                 self.send_command('validate')
                 self.send_command('discard')
-                self.send_command('quit-config')
-            return {'request': requests, 'response': responses, 'diff': diffs}
-        else:
-            return {'request': requests, 'response': responses}
+
+            self.send_command('exit all')
+            self.send_command('quit-config')
+
+            if diffs:
+                return {'request': requests, 'response': responses, 'diff': diffs}
+            else:
+                return {'request': requests, 'response': responses}
+
+        except AnsibleConnectionFailure as exc:
+            self.send_command('discard')
+            self.send_command('exit all')
+            self.send_command('quit-config')
+            raise exc
+
 
     def get(self, command, prompt=None, answer=None, sendonly=False, output=None, newline=True, check_all=False):
         if output:
@@ -285,20 +284,31 @@ class Cliconf(CliconfBase):
 
         self.enable_config_mode()
 
-        self.send_command('configure')
-        self.send_command('rollback {0}'.format(rollback_id).strip())
-        self.send_command('exit all')
-        diffs = self.send_command('compare').strip()
-        if diffs:
+        try:
+            self.send_command('configure')
+            self.send_command('rollback {0}'.format(rollback_id).strip())
+
+            diffs = self.send_command('compare /').strip()
+
             if commit:
                 self.send_command('commit')
-                self.send_command('quit-config')
             else:
+                self.send_command('validate')
                 self.send_command('discard')
-                self.send_command('quit-config')
-            return {'diff': diffs.strip()}
-        else:
-            return {}
+
+            self.send_command('exit all')
+            self.send_command('quit-config')
+
+            if diffs:
+                return {'diff': diffs}
+            else:
+                return {}
+
+        except AnsibleConnectionFailure as exc:
+            self.send_command('discard')
+            self.send_command('exit all')
+            self.send_command('quit-config')
+            raise exc
 
     def commit(self):
         if self.is_classic_cli():
@@ -306,6 +316,7 @@ class Cliconf(CliconfBase):
 
         if self.is_config_mode():
             self.send_command('commit')
+            self.send_command('exit all')
             self.send_command('quit-config')
 
     def discard_changes(self):
@@ -314,4 +325,5 @@ class Cliconf(CliconfBase):
 
         if self.is_config_mode():
             self.send_command('discard')
+            self.send_command('exit all')
             self.send_command('quit-config')

--- a/plugins/cliconf/md.py
+++ b/plugins/cliconf/md.py
@@ -211,7 +211,12 @@ class Cliconf(CliconfBase):
         elif source == 'candidate':
             response = self.send_command(' '.join(['info'] + flags + ['/']))
         else:
+            self.send_command('exit all')
+            if not self.is_config_mode():
+                self.send_command('edit-config read-only')
             response = self.send_command(' '.join(['info', source] + flags + ['/']))
+            self.send_command('exit all')
+            self.send_command('quit-config')
 
         return response
 

--- a/plugins/cliconf/md.py
+++ b/plugins/cliconf/md.py
@@ -175,11 +175,15 @@ class Cliconf(CliconfBase):
         # This Ansible module exits config-mode after any edit-config operation.
         # Therefore, accessing source='candidate' (when running in config-mode)
         # has been implemented for completeness only.
+        #
+        # Source 'active' and 'running' are equivalent. While 'running' covers
+        # the 'persistent-indices { ... }' section too, 'active' covers only the
+        # configuration itself.
 
         if flags is None:
             flags = []
 
-        if source not in ('startup', 'candidate', 'running', 'intended'):
+        if source not in ('startup', 'candidate', 'running', 'intended', 'active'):
             raise ValueError("fetching configuration from %s is not supported" % source)
 
         if format not in self.get_option_values()['format']:
@@ -210,13 +214,15 @@ class Cliconf(CliconfBase):
             self.send_command('quit-config')
         elif source == 'candidate':
             response = self.send_command(' '.join(['info'] + flags + ['/']))
-        else:
+        elif source == 'active':
             self.send_command('exit all')
             if not self.is_config_mode():
                 self.send_command('edit-config read-only')
-            response = self.send_command(' '.join(['info', source] + flags + ['/']))
+            response = self.send_command(' '.join(['info'] + flags + ['/']))
             self.send_command('exit all')
             self.send_command('quit-config')
+        else:
+           response = self.send_command(' '.join(['/admin show configuration', source] + flags))
 
         return response
 
@@ -247,6 +253,7 @@ class Cliconf(CliconfBase):
                         requests.append(cmd)
                         responses.append(self.send_command(cmd))
             elif replace:
+                # if replace from local file, copy to cflash first
                 if not bool(re.match(r'^[cC][fF][12345]:', replace)):
                     self._connection.copy_file(source=replace, destination='ansible.cfg', proto='scp', timeout=30)
                     replace = 'ansible.cfg'
@@ -279,6 +286,7 @@ class Cliconf(CliconfBase):
             self.send_command('exit all')
             self.send_command('quit-config')
             raise exc
+
 
     def get(self, command, prompt=None, answer=None, sendonly=False, output=None, newline=True, check_all=False):
         if output:

--- a/plugins/cliconf/md.py
+++ b/plugins/cliconf/md.py
@@ -276,7 +276,6 @@ class Cliconf(CliconfBase):
             self.send_command('quit-config')
             raise exc
 
-
     def get(self, command, prompt=None, answer=None, sendonly=False, output=None, newline=True, check_all=False):
         if output:
             raise ValueError("'output' value %s is not supported for get" % output)

--- a/tests/playbooks.yml
+++ b/tests/playbooks.yml
@@ -11,7 +11,7 @@ categories:
     description: "Test cases using mode-driven CLI mode"
     playbooks:
       - playbooks/sros_mdcli_config_demo.yml --diff
-      - playbooks/sros_mdcli_backup_restore_demo.yml
+      - playbooks/sros_mdcli_backup_restore_demo.yml -vvvv
       - playbooks/sros_mdcli_bulk_demo.yml --diff
       - playbooks/sros_mdcli_command_demo.yml
 

--- a/tests/playbooks.yml
+++ b/tests/playbooks.yml
@@ -11,7 +11,7 @@ categories:
     description: "Test cases using mode-driven CLI mode"
     playbooks:
       - playbooks/sros_mdcli_config_demo.yml --diff
-      - playbooks/sros_mdcli_backup_restore_demo.yml -vvvv
+      - playbooks/sros_mdcli_backup_restore_demo.yml
       - playbooks/sros_mdcli_bulk_demo.yml --diff
       - playbooks/sros_mdcli_command_demo.yml
 

--- a/tests/playbooks.yml
+++ b/tests/playbooks.yml
@@ -2,6 +2,7 @@ categories:
   classic-cli:
     description: "Test cases using classic CLI mode"
     playbooks:
+      - playbooks/sros_classic_cli_commission.yml
       - playbooks/sros_classic_cli_config_demo.yml --diff
       - playbooks/sros_classic_cli_backup_restore_demo.yml
       - playbooks/sros_classic_cli_command_demo.yml

--- a/tests/playbooks/sros_mdcli_backup_restore_demo.yml
+++ b/tests/playbooks/sros_mdcli_backup_restore_demo.yml
@@ -32,7 +32,6 @@
 
   - name: "restore backup (Success: MDCLI does support restore)"
     ansible.netcommon.cli_config:
-      replace: 'true'
-      config: "{{ lookup('file', backup_info.backup_path) }}"
+      replace: "{{ backup_info.backup_path }}"
     vars:
-      ansible_command_timeout: 300
+      ansible_command_timeout: 30

--- a/tests/playbooks/sros_mdcli_backup_restore_demo.yml
+++ b/tests/playbooks/sros_mdcli_backup_restore_demo.yml
@@ -31,7 +31,8 @@
           exit all
 
   - name: "restore backup (Success: MDCLI does support restore)"
-    cli_config:
+    ansible.netcommon.cli_config:
       replace: 'true'
       config: "{{ lookup('file', backup_info.backup_path) }}"
-...
+    vars:
+      ansible_command_timeout: 30

--- a/tests/playbooks/sros_mdcli_backup_restore_demo.yml
+++ b/tests/playbooks/sros_mdcli_backup_restore_demo.yml
@@ -33,6 +33,6 @@
   - name: "restore backup (Success: MDCLI does support restore)"
     ansible.netcommon.cli_config:
       replace: 'true'
-      config: "{{ lookup('file', backup_info.backup_path) }}"
+      config: "{{ lookup('file', backup_info.backup_path).splitlines() }}"
     vars:
       ansible_command_timeout: 30

--- a/tests/playbooks/sros_mdcli_backup_restore_demo.yml
+++ b/tests/playbooks/sros_mdcli_backup_restore_demo.yml
@@ -35,4 +35,4 @@
       replace: 'true'
       config: "{{ lookup('file', backup_info.backup_path) }}"
     vars:
-      ansible_command_timeout: 30
+      ansible_command_timeout: 300

--- a/tests/playbooks/sros_mdcli_backup_restore_demo.yml
+++ b/tests/playbooks/sros_mdcli_backup_restore_demo.yml
@@ -33,6 +33,6 @@
   - name: "restore backup (Success: MDCLI does support restore)"
     ansible.netcommon.cli_config:
       replace: 'true'
-      config: "{{ lookup('file', backup_info.backup_path).splitlines() }}"
+      config: "{{ lookup('file', backup_info.backup_path) }}"
     vars:
       ansible_command_timeout: 30

--- a/tests/playbooks/sros_mdcli_backup_restore_demo.yml
+++ b/tests/playbooks/sros_mdcli_backup_restore_demo.yml
@@ -8,10 +8,8 @@
 
   tasks:
   - name: backup
-    ansible.netcommon.cli_config:
-      backup: yes
-      backup_options:
-        dir_path: /tmp
+    ansible.netcommon.cli_backup:
+      dir_path: /tmp
     register: backup_info
 
   - name: backup details
@@ -33,5 +31,3 @@
   - name: "restore backup (Success: MDCLI does support restore)"
     ansible.netcommon.cli_config:
       replace: "{{ backup_info.backup_path }}"
-    vars:
-      ansible_command_timeout: 30

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -93,8 +93,12 @@ print_summary() {
   log INFO "Test Summary"
   log INFO "========================================="
   log INFO "Total tests:  $total"
-  log OK "Passed:       $TESTS_PASSED"
-  [[ $TESTS_FAILED -gt 0 ]] && log FAIL "Failed:       $TESTS_FAILED" || log INFO "Failed:       $TESTS_FAILED"
+  log INFO "Passed:       $TESTS_PASSED"
+  if [[ $TESTS_FAILED -gt 0 ]]; then
+    log FAIL "Failed:       $TESTS_FAILED"
+  else
+    log INFO "Failed:       $TESTS_FAILED"
+  fi
   
   if [[ $TESTS_FAILED -gt 0 ]]; then
     log INFO ""
@@ -233,9 +237,10 @@ run_tests() {
     
     log INFO "=== CATEGORY: $cat ==="
 
-    yaml_playbooks "$cat" | while IFS= read -r playbook; do    
+    while IFS= read -r playbook; do
+      [[ -n "$playbook" ]] || continue
       run_playbook "$playbook"
-    done
+    done < <(yaml_playbooks "$cat")
   done
   
   # Print summary at the end


### PR DESCRIPTION
### Added
- Support for `flat` and `xml` output formats in `get_config()`
- Support for `intended` as a valid configuration source in `get_config()`
- Support for commit comments in `edit_config()` using the `comment` parameter

### Changed
- Inherid base-class RPCs, while adding the SROS specific ones
- Use `info /` and `compare /` to ensure all tree levels are included in output
- Construct `info` commands using `' '.join()` to prevent trailing/double spaces when optional parameters are not provided
- Added exception handling for rollback

### Fixed
- Ensure `load full-replace` and `rollback` commands are correctly executed in CLI context `configure` as raised in #7 
- Ensure `quit-config` is correctly executed in CLI root context